### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: 1.16.4
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
 
       - name: Unshallow
         run: git fetch --prune --unshallow


### PR DESCRIPTION
## What

Bump GitHub Actions to their Node-24-native majors to clear the Node-20 runtime deprecation. GitHub force-migrates deprecated (Node-20) actions to Node 24 on **2026-06-16**; pinning ahead avoids surprise behaviour changes.

## Bump map

| action | after |
|---|---|
| actions/checkout | v6 |
| actions/setup-go | v6 |
| actions/setup-node | v6 |
| actions/cache | v5 |
| actions/setup-java | v5 |
| actions/setup-python | v6 |
| actions/upload-artifact | v7 |
| actions/download-artifact | v8 |

upload/download bumped as a matched pair (v7 ↔ v8) so the artifact handshake stays compatible.

Part of 🎯T4 (fleet-wide Actions deprecation sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)